### PR TITLE
idea: add overview as introduction for api domains

### DIFF
--- a/api-reference/members/overview.mdx
+++ b/api-reference/members/overview.mdx
@@ -1,0 +1,19 @@
+---
+title: 'Organization Members Overview'
+sidebarTitle: "Overview"
+description: 'Manage members in your organization'
+---
+
+The Organization Members API allows you to manage members within your organization.
+Members represent users who have access to your organization's resources via the web console.
+
+> **Note:** While all member management functionality is available through these API endpoints and nothing prevents you
+from building your own dashboard or managing Members via API, it is more convenient to manage Organization Members
+using Teal's web console.
+
+Use these endpoints to:
+- Create new organization members
+- Retrieve member information
+- List all members in your organization
+- Delete members
+- Authenticate members with sign-in functionality

--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -922,7 +922,7 @@ paths:
         "401":
           "$ref": "#/components/responses/UnauthorizedApiKey"
     get:
-      summary: Lists all the team members including the Owner
+      summary: Lists all the team members including the Admin
       parameters:
         - name: offset
           in: query
@@ -973,7 +973,7 @@ paths:
               $ref: "#/components/schemas/MemberSignInRequest"
       responses:
         "200":
-          description: Successful signin
+          description: Successful sign-in
           content:
             application/json:
               schema:
@@ -1349,13 +1349,14 @@ components:
         email:
           type: string
           format: email
-          example: john.smith@goteal.co
+          example: john.smith@yourcompany.co
         role:
           type: string
           description: The Role of the Member
+          enum: [Admin, FullMember]
           items:
             type: string
-          example: "Owner"
+          example: "Admin"
         name:
           type: string
           description: Names of the Member
@@ -1389,7 +1390,7 @@ components:
         email:
           type: string
           format: email
-          example: john.smith@goteal.co
+          example: john.smith@yourcompany.com
         role:
           type: string
           enum: [FullMember]
@@ -1417,7 +1418,7 @@ components:
         username:
           type: string
           description: The username of the member
-          example: john.doe@example.com
+          example: john.doe@yourcompany.com
         password:
           type: string
           description: The password of the member
@@ -1450,10 +1451,11 @@ components:
           type: string
           format: email
           description: Email address of the member
-          example: "john.doe@example.com"
+          example: "john.doe@yourcompany.com"
         role:
           type: string
           description: Role of the member
+          enum: [Admin, FullMember]
           example: "Admin"
         name:
           type: string

--- a/mint.json
+++ b/mint.json
@@ -112,8 +112,9 @@
       ]
     },
     {
-      "group": "Members",
+      "group": "Organization Members",
       "pages": [
+        "api-reference/members/overview",
         "api-reference/members/create",
         "api-reference/members/get",
         "api-reference/members/list",


### PR DESCRIPTION
+ adding some corrections in openapi.yml to make it easier to understand 

Instead of adding additional information regarding an API Domain at the top of the API Documentation, we can create an Overview section for each domain that can serve as an introduction and that links to other parts of the documentation if needed.

<img width="315" alt="Screenshot 2025-04-01 at 19 52 03" src="https://github.com/user-attachments/assets/2f011e99-00eb-4b00-9476-67d4cb0bb8b2" />

It could look like this instead, and it's closer to the information that you are searching for

<img width="290" alt="Screenshot 2025-04-01 at 19 51 21" src="https://github.com/user-attachments/assets/6c27c7d0-ca84-4b21-8aa1-4f6e2c4dd160" />

I found it useful in order to explain what Organisation Members are since it was difficult to understand

<img width="1342" alt="Screenshot 2025-04-01 at 19 51 36" src="https://github.com/user-attachments/assets/ac9085c3-5d92-4d4a-87c2-e93dd523b93c" />

If you are a Lender it is difficult to take advantage of these endpoints. If we consider that it would be very likely that nobody will use them I would vote for deleting them, since it removes cognitive load from person in charge of the integration. In the meantime, we can have the overview so they can figure what those endpoints are earlier 