### PR TITLE
fix: change PUT to PATCH for partial-update endpoints

### DIFF
--- a/api-reference/configuration/update.mdx
+++ b/api-reference/configuration/update.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update client configuration'
-openapi: 'PUT /configuration'
+openapi: 'PATCH /configuration'
 ---
 
 

--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -110,7 +110,7 @@ paths:
           "$ref": "#/components/responses/BadRequest"
         "401":
           "$ref": "#/components/responses/UnauthorizedApiKey"
-    put:
+    patch:
       description: Update a user and its config. If a field is sent as null then it is considered an unset or removal.
       summary: Updates a user.
       parameters:
@@ -1211,7 +1211,7 @@ paths:
           "$ref": "#/components/responses/UnauthorizedApiKey"
         "404":
           "$ref": "#/components/responses/ResourceNotFound"
-    put:
+    patch:
       summary: Updates the client configuration
       description: Partial updates supported; omitted fields preserve their existing values.
       requestBody:

--- a/api-reference/users/update.mdx
+++ b/api-reference/users/update.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update a User'
-openapi: 'PUT /users/{user_id}'
+openapi: 'PATCH /users/{user_id}'
 ---
 
 **Direct Connection Requirements**


### PR DESCRIPTION
## Summary
- `PATCH /users/{user_id}` — was `PUT`; uses partial-update semantics so PATCH is correct
- `PATCH /configuration` — same reason
- Updates `openapi.yml` and the two `.mdx` page definitions

Related: Teal-Connect/payroll-api#974