### PR TITLE
docs: document one-time authorisation expiry behaviour

### DIFF
--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -1846,6 +1846,10 @@ components:
               "$ref": "#/components/schemas/Date"
               description: Server timestamp when the authorisation was revoked
               nullable: true
+            expires_at:
+              "$ref": "#/components/schemas/Date"
+              description: Expiry timestamp for the authorisation. Present for one-time authorisations, which expire 1 day after acceptance. Null for recurring authorisations.
+              nullable: true
             created_at:
               "$ref": "#/components/schemas/Date"
               description: When the authorisation record was created

--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -1743,7 +1743,7 @@ components:
     AuthorisationStatus:
       type: string
       description: The status of a authorisation record
-      enum: [active, revoked]
+      enum: [active, revoked, expired]
       example: active
     AuthorisationTerm:
       type: object

--- a/authorisations.mdx
+++ b/authorisations.mdx
@@ -20,7 +20,7 @@ Authorisation terms define the legal text that users agree to when granting acce
 
 Each term belongs to a category that defines the type of authorisation:
 
-- **one_time** - Single authorisation for a specific action (e.g., one-time income verification)
+- **one_time** - Single authorisation for a specific action (e.g., one-time income verification). One-time authorisations expire after 1 day, after which the user must re-authorise.
 - **recurring** - Ongoing authorisation for continuous data access (e.g., recurring payroll checks)
 
 ### Retrieving Available Terms
@@ -136,6 +136,7 @@ Each acceptance creates an immutable record containing:
 - **ip_address** - Captured from request headers or provided in request
 - **user_agent** - Browser or application identifier
 - **accepted_at** - Server timestamp of acceptance
+- **expires_at** - Expiry timestamp for the authorisation. Present for one-time authorisations.
 - **status** - `active` or `revoked`
 
 ## Validating Authorisation
@@ -154,10 +155,14 @@ curl --request GET \
 
 Each authorisation record includes an `is_valid` field that indicates whether the authorisation is currently valid:
 
-- `is_valid: true` - Authorisation status is `active` AND the associated term is active
-- `is_valid: false` - Either authorisation is revoked OR the term has been deactivated
+- `is_valid: true` - Authorisation status is `active` AND the associated term is active AND the authorisation has not expired
+- `is_valid: false` - Either authorisation is revoked, the term has been deactivated, or the authorisation has expired
 
 If `is_valid` is false because the term was deactivated, the user needs to re-authorise to the new term.
+
+<Note>
+One-time authorisations automatically expire. Once expired, the user must re-authorise before any further actions can be performed. Check the `expires_at` field on the authorisation record to see when it expires.
+</Note>
 
 ## Re-authorisation Flow
 

--- a/authorisations.mdx
+++ b/authorisations.mdx
@@ -137,7 +137,7 @@ Each acceptance creates an immutable record containing:
 - **user_agent** - Browser or application identifier
 - **accepted_at** - Server timestamp of acceptance
 - **expires_at** - Expiry timestamp for the authorisation. Present for one-time authorisations.
-- **status** - `active` or `revoked`
+- **status** - `active`, `revoked`, or `expired`
 
 ## Validating Authorisation
 


### PR DESCRIPTION
## Summary

- Documents that one-time authorisations expire after 1 day, requiring users to re-authorise
- Adds `expires_at` field to the authorisation API response schema (nullable, present for one-time authorisations)
- Updates `is_valid` validation logic to account for expiry as a condition

## Changes

**`authorisations.mdx`**
- Updated `one_time` category description to mention 1-day expiry
- Added `expires_at` to the authorisation record field listing
- Updated validation logic to include expiry, with a callout note

**`api-reference/openapi.yml`**
- Added `expires_at` (nullable Date) to `CreatedAuthorisation` schema

No changes to list consents endpoint — status filter remains `active`/`revoked`.