### PR TITLE
docs: add source field to payroll submission responses

### DIFF
--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -2825,6 +2825,14 @@ components:
         fraud_risk:
           "$ref": "#/components/schemas/FraudRisk"
           nullable: true
+        source:
+          type: string
+          description: The source of the payroll data
+          example: Payroll (via Direct Connection)
+          enum:
+            - Payroll (via Direct Connection)
+            - Payroll (via User Connection)
+            - Payslip (via Doc Scan)
     IdentityInformation:
       type: object
       properties:

--- a/api-reference/payroll/payslips-create.mdx
+++ b/api-reference/payroll/payslips-create.mdx
@@ -431,6 +431,7 @@ System.out.println(submitResponse.getBody());
       "created_at": "2019-05-17T00:00:00.000Z",
       "document_external_id": "payslip123456",
       "document_filename": "file1-payslip.pdf",
+      "source": "Payslip (via Doc Scan)",
       "identity_information": {
         "name": "John Smith",
         "date_of_birth": "2019-05-17T00:00:00.000Z",

--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -475,6 +475,7 @@ is related to uploading a payslip.
         "created_at": "2024-04-17T13:56:03.118Z",
         "document_external_id": null,
         "document_filename": null,
+        "source": "Payroll (via Direct Connection)",
         "identity_information": {
           "name": "Jane Doe",
           "date_of_birth": "1990-04-01",

--- a/data.mdx
+++ b/data.mdx
@@ -84,7 +84,11 @@ curl --request GET \
   --header 'X-API-KEY: <api-key>''
 ```
 
-The structure of the returned data will contain fields on employment, identity and income. 
+The structure of the returned data will contain fields on employment, identity and income. Each payroll submission includes a `source` field indicating how the data was obtained:
+
+- **Payroll (via Direct Connection)** – Data retrieved from direct API integrations with payroll providers
+- **Payroll (via User Connection)** – Data obtained through user-authenticated scraping of payroll accounts
+- **Payslip (via Doc Scan)** – Data extracted from uploaded payslip documents 
 
 ### Documents `/documents`
 


### PR DESCRIPTION
## Summary
- Added new `source` field to `PayrollSubmission` schema in OpenAPI specification
- Updated response examples in payslip upload and webhook documentation
- Added explanation of source field values in main data documentation

## Changes
The `source` field indicates the origin of payroll data with three possible values:
- `Payroll (via Direct Connection)` - Direct API integrations with payroll providers
- `Payroll (via User Connection)` - User-authenticated scraping of payroll accounts
- `Payslip (via Doc Scan)` - Data extracted from uploaded payslip documents

## Affected Files
- `api-reference/openapi.yml` - Added source field to PayrollSubmission schema
- `api-reference/payroll/payslips-create.mdx` - Updated response example
- `api-reference/webhooks.mdx` - Updated webhook payload example
- `data.mdx` - Added source field explanation

## Test plan
- [ ] Verify OpenAPI schema renders correctly in documentation
- [ ] Check that all response examples display the source field
- [ ] Confirm data.mdx explanation is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)