### PR TITLE
feat: add GET /bankstatements endpoint, bank statement webhook, and extracted data fields

### DIFF
--- a/api-reference/documents/bank-statements-get.mdx
+++ b/api-reference/documents/bank-statements-get.mdx
@@ -1,0 +1,4 @@
+---
+title: 'List bank statement submissions'
+openapi: 'GET /bankstatements/{user_id}'
+---

--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -937,23 +937,7 @@ paths:
                     type: array
                     description: Successfully processed bank statements
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                        created_at:
-                          "$ref": "#/components/schemas/Date"
-                        document_id:
-                          type: string
-                          format: uuid
-                          nullable: true
-                        document_external_id:
-                          type: string
-                          nullable: true
-                        document_filename:
-                          type: string
-                          nullable: true
+                      "$ref": "#/components/schemas/BankStatementSubmission"
                   bank_statement_errors:
                     type: array
                     description: Files that failed extraction
@@ -973,9 +957,12 @@ paths:
                 properties:
                   bank_statement_submissions:
                     type: array
-                    items: {}
+                    description: Successfully processed bank statements
+                    items:
+                      "$ref": "#/components/schemas/BankStatementSubmission"
                   bank_statement_errors:
                     type: array
+                    description: Files that failed extraction
                     items:
                       type: object
                       properties:
@@ -1015,6 +1002,74 @@ paths:
           "$ref": "#/components/responses/BadRequest"
         "401":
           "$ref": "#/components/responses/UnauthorizedBearer"
+  "/bankstatements/{user_id}":
+    get:
+      summary: Returns all bank statement submissions for a user
+      description: |
+        Retrieve paginated bank statement submissions for a given user.
+        Each submission includes the extracted data (account information,
+        statement period, balance information, and transactions) when available.
+      parameters:
+        - in: path
+          name: user_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: ID of the user to get bank statements for
+        - name: offset
+          in: query
+          description: The offset to start at
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          description: The number of items to return
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - name: created_after
+          in: query
+          description: Filter out bank statements created before the given date
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: 2024-01-01T00:00:00.000Z
+        - name: created_before
+          in: query
+          description: Filter out bank statements created after the given date
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: 2024-12-31T23:59:59.000Z
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pagination:
+                    "$ref": "#/components/schemas/Pagination"
+                  bank_statement_submissions:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/BankStatementSubmission"
+        "400":
+          "$ref": "#/components/responses/BadRequest"
+        "401":
+          "$ref": "#/components/responses/UnauthorizedApiKey"
   "/webhooks":
     post:
       summary: Creates a webhook.
@@ -2525,6 +2580,131 @@ components:
           type: string
           description: File name of the uploaded document
           nullable: true
+    BankStatementSubmission:
+      type: object
+      required: [id, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique bank statement submission identifier
+          example: 95a0e70b-fe02-4f47-aef9-2efff279df71
+        created_at:
+          "$ref": "#/components/schemas/Date"
+        document_id:
+          type: string
+          format: uuid
+          description: ID of the linked raw document, if available
+          nullable: true
+        document_external_id:
+          type: string
+          description: External ID provided during upload, if any
+          nullable: true
+        document_filename:
+          type: string
+          description: File name of the uploaded document
+          nullable: true
+        account_information:
+          "$ref": "#/components/schemas/BankStatementAccountInformation"
+          nullable: true
+        statement_period:
+          "$ref": "#/components/schemas/BankStatementStatementPeriod"
+          nullable: true
+        balance_information:
+          "$ref": "#/components/schemas/BankStatementBalanceInformation"
+          nullable: true
+        transactions:
+          type: array
+          description: List of transactions extracted from the bank statement
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/BankStatementTransaction"
+        bank_statement_probability:
+          type: number
+          format: float
+          description: Confidence score (0-1) that the document is a genuine bank statement
+          nullable: true
+          example: 0.95
+    BankStatementAccountInformation:
+      type: object
+      description: Account holder and bank details extracted from the bank statement
+      properties:
+        account_holder_name:
+          type: string
+          description: Name of the account holder
+          nullable: true
+          example: "JANE DOE"
+        account_number:
+          type: string
+          description: Bank account number
+          nullable: true
+          example: "12345678"
+        sort_code:
+          type: string
+          description: Sort code of the bank account
+          nullable: true
+          example: "12-34-56"
+        bank_name:
+          type: string
+          description: Name of the bank
+          nullable: true
+          example: "HSBC"
+        iban:
+          type: string
+          description: IBAN of the bank account
+          nullable: true
+    BankStatementStatementPeriod:
+      type: object
+      description: Time period covered by the bank statement
+      properties:
+        start_date:
+          type: string
+          description: Start date of the statement period
+          nullable: true
+          example: "2024-01-01"
+        end_date:
+          type: string
+          description: End date of the statement period
+          nullable: true
+          example: "2024-01-31"
+    BankStatementBalanceInformation:
+      type: object
+      description: Opening and closing balances from the bank statement
+      properties:
+        opening_balance:
+          type: string
+          description: Opening balance at the start of the statement period
+          nullable: true
+          example: "1,000.00"
+        closing_balance:
+          type: string
+          description: Closing balance at the end of the statement period
+          nullable: true
+          example: "1,250.00"
+    BankStatementTransaction:
+      type: object
+      description: A single transaction from the bank statement
+      properties:
+        date:
+          type: string
+          description: Date of the transaction
+          nullable: true
+          example: "2024-01-15"
+        description:
+          type: string
+          description: Transaction description
+          nullable: true
+          example: "Salary Payment"
+        amount:
+          type: string
+          description: Transaction amount
+          nullable: true
+          example: "2,500.00"
+        type:
+          type: string
+          description: Transaction type (credit or debit)
+          nullable: true
+          example: "credit"
     PayrollData:
       type: object
       required: [account_id, entry_id, pagination, payroll_submissions]
@@ -2560,7 +2740,7 @@ components:
           type: array
           items:
             type: string
-          example: ["user-payroll-submitted", "user-payroll-created"]
+          example: ["user-payroll-submitted", "user-hmrc-data-submitted", "user-bank-statement-submitted"]
         url:
           type: string
           format: url

--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -20,7 +20,9 @@ Webhooks are system-wide meaning subscriptions are not limited to specific users
 ### Supported Event:
 - `user-payroll-submitted` - notifies when any user creates an entry with new payroll data.
    Includes the payroll data entry as json if `include_payload` is set in the configuration.
-- No more events are supported at the moment.
+- `user-bank-statement-submitted` - notifies when any user uploads bank statements that are
+   successfully extracted. Includes bank statement submissions as json if `include_payload` is set
+   in the configuration.
 
 ## Setting Up Webhooks
 
@@ -39,7 +41,7 @@ curl --request POST \
     "url": "https://webhooks.site"
   }'
 ```
-- **events**: Choose events like `user-payroll-submitted` for targeted notifications.
+- **events**: Choose events like `user-payroll-submitted` or `user-bank-statement-submitted` for targeted notifications.
 - **name**: Label your webhook for easier management.
 - **url**: Your endpoint to receive webhook payloads.
 - **signing_secret**: (Optional) A secret for secure webhook verification.
@@ -515,6 +517,64 @@ is related to uploading a payslip.
             }
           }
         }
+      }
+    ]
+  }
+}
+```
+
+### Bank Statement Webhook Example
+
+Example of a `user-bank-statement-submitted` webhook request body configured with `include_payload` enabled.
+
+The `document_external_ids` array contains the external IDs provided during upload, if any.
+When `include_payload` is enabled, the `payload` object contains the full bank statement
+submission data including extracted account information, balances, and transactions.
+
+```json
+{
+  "event": "user-bank-statement-submitted",
+  "user_id": "e9b7676b-f107-429c-8d17-cf3fd1362fd3",
+  "timestamp": "2024-04-17T13:56:03.277Z",
+  "document_external_ids": ["ext-stmt-2024-01"],
+  "payload": {
+    "bank_statement_submissions": [
+      {
+        "id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
+        "created_at": "2024-04-17T13:56:03.118Z",
+        "document_id": "a9249254-ab10-4a2d-b709-eda95f5ecd59",
+        "document_external_id": "ext-stmt-2024-01",
+        "document_filename": "hsbc-january-2024.pdf",
+        "account_information": {
+          "account_holder_name": "JANE DOE",
+          "account_number": "12345678",
+          "sort_code": "12-34-56",
+          "bank_name": "HSBC",
+          "iban": null
+        },
+        "statement_period": {
+          "start_date": "2024-01-01",
+          "end_date": "2024-01-31"
+        },
+        "balance_information": {
+          "opening_balance": "1,000.00",
+          "closing_balance": "1,250.00"
+        },
+        "transactions": [
+          {
+            "date": "2024-01-15",
+            "description": "Salary Payment",
+            "amount": "2,500.00",
+            "type": "credit"
+          },
+          {
+            "date": "2024-01-20",
+            "description": "Rent",
+            "amount": "-1,250.00",
+            "type": "debit"
+          }
+        ],
+        "bank_statement_probability": 0.95
       }
     ]
   }

--- a/docs.json
+++ b/docs.json
@@ -82,7 +82,8 @@
               "api-reference/documents/get",
               "api-reference/documents/delete",
               "api-reference/documents/bank-statements-presign",
-              "api-reference/documents/bank-statements-upload"
+              "api-reference/documents/bank-statements-upload",
+              "api-reference/documents/bank-statements-get"
             ]
           },
           {


### PR DESCRIPTION
## Summary

- Add **GET `/bankstatements/{user_id}`** paginated endpoint documentation with `offset`, `limit`, `created_after`, `created_before` query params
- Add **`user-bank-statement-submitted`** webhook event documentation with example payload
- Expand **bank statement submission response** schema to include extracted data fields: `account_information`, `statement_period`, `balance_information`, `transactions`, `bank_statement_probability`
- Fix 200 response on PUT `/documents/bank-statements` that was rendering as `<unknown>` in Mintlify

### Files changed
- `api-reference/openapi.yml` — new endpoint path, shared `BankStatementSubmission` schema with sub-schemas, updated webhook event list
- `api-reference/webhooks.mdx` — documented `user-bank-statement-submitted` event with example
- `api-reference/documents/bank-statements-get.mdx` — new Mintlify page for GET endpoint
- `docs.json` — added bank-statements-get to Documents navigation