### PR TITLE
Sync Postman collection on openapi.yml push to main

### DIFF
--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -1,0 +1,36 @@
+name: Sync Postman collection
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'api-reference/openapi.yml'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Convert OpenAPI to Postman collection
+        run: |
+          npx --yes openapi-to-postmanv2 \
+            -s api-reference/openapi.yml \
+            -o /tmp/collection.json \
+            -p
+
+      - name: Push to Postman API
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
+        run: |
+          COLLECTION=$(cat /tmp/collection.json)
+          curl --fail -s -X PUT \
+            "https://api.getpostman.com/collections/$POSTMAN_COLLECTION_UID" \
+            -H "X-Api-Key: $POSTMAN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"collection\": $COLLECTION}"

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -26,11 +26,10 @@ jobs:
       - name: Push to Postman API
         env:
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
-          POSTMAN_COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
         run: |
           jq '{collection: .}' /tmp/collection.json > /tmp/body.json
           curl --fail -s -X PUT \
-            "https://api.getpostman.com/collections/$POSTMAN_COLLECTION_UID" \
+            "https://api.getpostman.com/collections/34133704-ca42908e-fbb8-4a53-9cde-681b4486dc49" \
             -H "X-Api-Key: $POSTMAN_API_KEY" \
             -H "Content-Type: application/json" \
             -d @/tmp/body.json

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -1,6 +1,7 @@
 name: Sync Postman collection
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           jq '{collection: .}' /tmp/collection.json > /tmp/body.json
           curl --fail -s -X PUT \
-            "https://api.getpostman.com/collections/34133704-ca42908e-fbb8-4a53-9cde-681b4486dc49" \
+            "https://api.getpostman.com/collections/34096189-b77feaba-4ca9-4456-a365-6a771e02ccad" \
             -H "X-Api-Key: $POSTMAN_API_KEY" \
             -H "Content-Type: application/json" \
             -d @/tmp/body.json

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -29,9 +29,9 @@ jobs:
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
           POSTMAN_COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
         run: |
-          COLLECTION=$(cat /tmp/collection.json)
+          jq '{collection: .}' /tmp/collection.json > /tmp/body.json
           curl --fail -s -X PUT \
             "https://api.getpostman.com/collections/$POSTMAN_COLLECTION_UID" \
             -H "X-Api-Key: $POSTMAN_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"collection\": $COLLECTION}"
+            -d @/tmp/body.json

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -1,7 +1,6 @@
 name: Sync Postman collection
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -82,17 +82,17 @@ paths:
     description: A User represents the borrowers and end-users that give
       authorised access and/or upload their payslips to our API.
     get:
-      summary: Creates a user.
+      summary: Returns a user.
       parameters:
         - in: path
           name: user_id
           schema:
             type: string
           required: true
-          description: ID of the user to delete.
+          description: ID of the user to retrieve.
       responses:
         "200":
-          description: REturns the user details
+          description: Returns the user details
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-postman.yml` — fires on every push to `main` when `api-reference/openapi.yml` changes
- Converts the OpenAPI spec to Postman collection format using `openapi-to-postmanv2`
- PUTs the result to the Postman API to keep the public collection in sync automatically

## Pre-requisites before merging

Two secrets must be added to the repo (Settings → Secrets → Actions):
- `POSTMAN_API_KEY` — generate at https://go.postman.co/settings/me/api-keys
- `POSTMAN_COLLECTION_UID` — the UID of the existing public collection

## Test plan

- [ ] Add the two secrets to the repo
- [ ] Merge this PR
- [ ] Make a small change to `api-reference/openapi.yml` and push to `main`
- [ ] Confirm the "Sync Postman collection" workflow run passes in the Actions tab
- [ ] Open the public Postman collection and verify the change is reflected

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)