### PR TITLE
docs: add fraud_details to API reference (#1075)

### DIFF
--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -1985,6 +1985,23 @@ components:
       description: The fraud risk level assessment. Fraud risk will be present if the payroll data is coming from a payslip source
       enum: [Low, Medium, High]
       example: Low
+    FraudDetail:
+      type: object
+      required: [rule, probability, description]
+      properties:
+        rule:
+          type: string
+          description: The fraud rule that was triggered
+          example: OVERLAPPING_BOUNDING_BOXES
+        probability:
+          type: number
+          format: double
+          description: The weight/probability of this rule (0.0 to 1.0)
+          example: 0.6
+        description:
+          type: string
+          description: Human-readable explanation of what was detected
+          example: Detected overlapping text layers on page 1
     PaginationWithOrderedBy:
       type: object
       allOf:
@@ -2825,6 +2842,12 @@ components:
         fraud_risk:
           "$ref": "#/components/schemas/FraudRisk"
           nullable: true
+        fraud_details:
+          type: array
+          nullable: true
+          description: Detailed breakdown of individual fraud checks that were triggered. Present when fraud_risk is not null.
+          items:
+            "$ref": "#/components/schemas/FraudDetail"
         source:
           type: string
           description: The source of the payroll data

--- a/api-reference/payroll/payslips-create.mdx
+++ b/api-reference/payroll/payslips-create.mdx
@@ -471,10 +471,14 @@ System.out.println(submitResponse.getBody());
           "employee_pension": 300,
           "total_deductions": 1000
         }
-      }
-    },
-    "fraud_risk": "Low"
-    ],
+      },
+      "fraud_risk": "Medium",
+      "fraud_details": [
+        { "rule": "DOCUMENT_MODIFIED_INCONSISTENT_DATES_MID", "probability": 0.2, "description": "Creation date 2024-01-01, modification date 2023-06-15" },
+        { "rule": "OVERLAPPING_BOUNDING_BOXES", "probability": 0.6, "description": "Detected overlapping text layers on page 1" }
+      ]
+    }
+  ],
   "payslip_errors" : [{
     "error" : "File is not a payslip",
     "file_name" : "Payslip3.pdf"

--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -515,7 +515,9 @@ is related to uploading a payslip.
               "total_deductions": 500
             }
           }
-        }
+        },
+        "fraud_risk": null,
+        "fraud_details": null
       }
     ]
   }

--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -699,7 +699,8 @@ curl --request GET \
       "document_external_id": null,
       "document_filename": null,
       "document_filename": "file1-payslip.pdf",
-      "fraud_risk": "Low"
+      "fraud_risk": "Low",
+      "fraud_details": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `FraudDetail` schema to OpenAPI spec (rule, probability, description)
- Adds `fraud_details` array field to PayrollSubmission schema
- Updates response examples in payslips-create, webhooks, and sandbox docs

## Test plan
- [ ] Verify OpenAPI spec validates correctly
- [ ] Preview rendered docs show the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes Teal-Connect/payroll-api#1075