### PR TITLE
Add workflow_dispatch trigger to sync-postman workflow

### DIFF
--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -1,6 +1,7 @@
 name: Sync Postman collection
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Allows manually triggering the Postman collection sync from the GitHub Actions UI or CLI.