### PR TITLE
Remove workflow_dispatch from sync-postman workflow

### DIFF
--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -1,7 +1,6 @@
 name: Sync Postman collection
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Cleanup: removes the temporary manual trigger added for debugging. Workflow now only runs automatically on push to `api-reference/openapi.yml` on main.