### PR TITLE
Reframe fraud language to trust-oriented terminology

### DIFF
--- a/api-reference/openapi.yml
+++ b/api-reference/openapi.yml
@@ -2035,11 +2035,11 @@ components:
               "$ref": "#/components/schemas/Date"
               description: When the authorisation record was created
         - "$ref": "#/components/schemas/AuthorisationAcceptance"
-    FraudRisk:
+    TrustScore:
       type: string
-      description: The fraud risk level assessment. Fraud risk will be present if the payroll data is coming from a payslip source
+      description: The document trust score assessment. Trust score will be present if the payroll data is coming from a payslip source
       enum: [Low, Medium, High]
-      example: Low
+      example: High
     PaginationWithOrderedBy:
       type: object
       allOf:
@@ -2998,8 +2998,8 @@ components:
           $ref: "#/components/schemas/EmploymentInformation"
         income_information:
           $ref: "#/components/schemas/IncomeInformation"
-        fraud_risk:
-          "$ref": "#/components/schemas/FraudRisk"
+        trust_score:
+          "$ref": "#/components/schemas/TrustScore"
           nullable: true
         source:
           type: string

--- a/api-reference/payroll/payslips-create.mdx
+++ b/api-reference/payroll/payslips-create.mdx
@@ -473,7 +473,7 @@ System.out.println(submitResponse.getBody());
         }
       }
     },
-    "fraud_risk": "Low"
+    "trust_score": "High"
     ],
   "payslip_errors" : [{
     "error" : "File is not a payslip",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -38,7 +38,7 @@ If a direct API connection isn't available, Teal prompts the user to securely au
 
 ## 3. Doc Scan
 
-If digital connections fail or the user cannot remember their credentials, Teal seamlessly falls back to document upload. Unlike generic OCR, Teal's purpose-built extraction models interrogate the uploaded payslip's metadata, validate the mathematics (Gross vs. Net), and check for pixel anomalies to prevent sophisticated fraud.
+If digital connections fail or the user cannot remember their credentials, Teal seamlessly falls back to document upload. Unlike generic OCR, Teal's purpose-built extraction models interrogate the uploaded payslip's metadata, validate the mathematics (Gross vs. Net), and check for pixel anomalies for a better assessment.
 
 # Real-Time Updates via Webhooks
 
@@ -108,4 +108,4 @@ Regardless of which path the user takes in the waterfall, the data always arrive
 Ready to start building? Here is how to get your first test data flowing.
 - Get your API Keys: Contact our team at hello@goteal.co to schedule a quick intro call, and we will provision your Sandbox keys.
 
-- [Explore the Sandbox](https://docs.goteal.co/sandbox): Learn how to use our test credentials to simulate successful User Connections, direct connections, and fraudulent document uploads.
+- [Explore the Sandbox](https://docs.goteal.co/sandbox): Learn how to use our test credentials to simulate successful User Connections, direct connections, and document uploads.

--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -699,7 +699,7 @@ curl --request GET \
       "document_external_id": null,
       "document_filename": null,
       "document_filename": "file1-payslip.pdf",
-      "fraud_risk": "Low"
+      "trust_score": "High"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renamed `fraud_risk` → `trust_score` in OpenAPI schema and all example responses
- Removed "fraud" / "fraudulent" from introduction and sandbox prose
- Aligned with website reframing (commit 1cba14f)

## Test plan
- [ ] `mintlify dev` — verify introduction, sandbox, and API reference pages render correctly
- [ ] Search docs for remaining "fraud" references (should be zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)