### PR TITLE
Remove outdated sandbox personas direct-connections-only note

### DIFF
--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -13,11 +13,6 @@ This environment employs mock payroll providers and payslip readers in order to 
 
 The sandbox environment includes three pre-configured test personas with corresponding mock data in the backend. Use these personas to test different workflows throughout this guide.
 
-<Note>
-  These test personas currently return mock data for direct connections only.
-  Support for other endpoints is coming soon.
-</Note>
-
 **Persona 1: Sarah Chen**
 
 ```json


### PR DESCRIPTION
## Summary

- Removes the `<Note>` block that stated personas only return mock data for direct connections
- Personas now also work for user connections (matched by forename and surname), so the restriction no longer applies
- Related: Teal-Connect/payroll-api#1185