### PR TITLE
Update logo_url example to infra webapp distro

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1852,7 +1852,7 @@ components:
           type: string
           format: uri
           description: URL to the employer's logo
-          example: https://d1wfx42f6qh83.cloudfront.net/logos/teal_0d28113814a9.png
+          example: https://d3hi2i04139ueq.cloudfront.net/logos/teal_0d28113814a9.png
         providers:
           type: array
           description: List of provider IDs associated with this employer


### PR DESCRIPTION
## What

Updates the `logo_url` example in the OpenAPI spec (`api-reference/openapi.yaml`) from the old management-account distro `d1wfx42f6qh83` to the new infra webapp distro `d3hi2i04139ueq.cloudfront.net`, for consistency with the webapp-resources migration.

Refs Teal-Connect/payroll-api#1232