### PR TITLE
Add docs for gov-connect endpoints and HMRC untied flow

### DIFF
--- a/api-reference/gov-connect/connections-create.mdx
+++ b/api-reference/gov-connect/connections-create.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Fetch Gov Connect income'
+openapi: 'POST /gov-connect/entries/connections'
+---

--- a/api-reference/gov-connect/get.mdx
+++ b/api-reference/gov-connect/get.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Gov Connect income'
+openapi: 'GET /gov-connect/{user_id}'
+---

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1666,6 +1666,126 @@ paths:
                 "$ref": "#/components/schemas/ProvidersResponse"
         "401":
           "$ref": "#/components/responses/UnauthorizedApiKey"
+  "/gov-connect/entries/connections":
+    description:
+      For a Gov Connect (HMRC) account, a call to the `/gov-connect/entries/connections`
+      endpoint fetches the latest income data from HMRC for that account and persists it
+      on Teal's storage. The stored data can subsequently be retrieved using the
+      `GET /gov-connect/{user_id}` endpoint. The account must have been established via a
+      Gov Connect connection (e.g. the `hmrc_untied` provider) and the user must have HMRC
+      enabled and a valid authorisation.
+    post:
+      summary: Fetch and store Gov Connect (HMRC) income data for an account
+      parameters:
+        - "$ref": "#/components/parameters/XAuthorisationId"
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GovConnectEntriesRequest"
+      responses:
+        "200":
+          description: OK — no new income data was returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GovConnectData"
+        "201":
+          description: Created — income data was fetched and stored
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GovConnectData"
+        "400":
+          "$ref": "#/components/responses/BadRequest"
+        "401":
+          "$ref": "#/components/responses/UnauthorizedBearer"
+        "403":
+          description: Forbidden — the user does not have a valid authorisation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/gov-connect/{user_id}":
+    description:
+      Retrieve the Gov Connect (HMRC) income data that has been submitted for a user,
+      either through a connected Gov Connect account or fetched via
+      `POST /gov-connect/entries/connections`. The response contains submissions in the
+      Making Tax Digital (MTD) shape.
+    get:
+      summary: Returns all Gov Connect (HMRC) income submissions for a user
+      parameters:
+        - in: path
+          name: user_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: ID of the user to get Gov Connect income for
+        - name: offset
+          in: query
+          description: The offset to start at
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          description: The number of items to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            default: 100
+        - name: account_id
+          in: query
+          description: Filter submissions to a single account
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: entry_id
+          in: query
+          description: Filter submissions to a single ingestion entry
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: created_after
+          in: query
+          description: Filter out submissions dated before the given date
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: 2019-05-17T00:00:00.000Z
+        - name: created_before
+          in: query
+          description: Filter out submissions dated after the given date
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: 2019-05-17T00:00:00.000Z
+      responses:
+        "200":
+          description: Gov Connect income response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedGovConnect"
+        "400":
+          "$ref": "#/components/responses/BadRequest"
+        "401":
+          "$ref": "#/components/responses/UnauthorizedApiKey"
+        "404":
+          "$ref": "#/components/responses/ResourceNotFound"
 components:
   responses:
     UnauthorizedApiKey:
@@ -3149,6 +3269,170 @@ components:
           type: number
           description: The total deductions
           example: 1000
+
+    GovConnectEntriesRequest:
+      type: object
+      required: [account_id]
+      properties:
+        account_id:
+          type: string
+          format: uuid
+          description: The Gov Connect (HMRC) account id to fetch income data for
+          example: 95a0e70b-fe02-4f47-aef9-2efff279df71
+
+    PaginatedGovConnect:
+      type: object
+      required: [pagination, gov_connect_submissions]
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        gov_connect_submissions:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GovConnectSubmission"
+
+    GovConnectData:
+      type: object
+      required: [account_id, gov_connect_submissions]
+      properties:
+        account_id:
+          type: string
+          format: uuid
+          description: The account the income data belongs to
+          example: 95a0e70b-fe02-4f47-aef9-2efff279df71
+        entry_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ingestion entry created for this fetch. Null when no data was returned.
+          example: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+        gov_connect_submissions:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GovConnectSubmission"
+
+    GovConnectSubmission:
+      type: object
+      description:
+        A single Gov Connect (HMRC) income submission in the Making Tax Digital (MTD)
+        shape. Only the fields present for the taxpayer are returned; empty fields are
+        omitted. All monetary values are returned as strings.
+      required: [id, account_id, entry_id, authorisation_id]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The submission id
+          example: 3f1c0b9a-1e2d-4a5b-9c8d-0e1f2a3b4c5d
+        account_id:
+          type: string
+          format: uuid
+          example: 95a0e70b-fe02-4f47-aef9-2efff279df71
+        entry_id:
+          type: string
+          format: uuid
+          example: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+        authorisation_id:
+          type: string
+          format: uuid
+          example: 9f8e7d6c-5b4a-3210-fedc-ba9876543210
+        income_id:
+          type: string
+          description: Stable identifier for the income record
+          example: "2025-26:emp:se:prop"
+        identity:
+          type: object
+          properties:
+            name:
+              type: string
+              example: Fred Bloggs
+            date_of_birth:
+              type: string
+              example: "1980-02-20"
+            ni_number:
+              type: string
+              example: QQ000001A
+        employments:
+          type: array
+          items:
+            type: object
+            properties:
+              employment:
+                type: object
+                properties:
+                  employer_name:
+                    type: string
+                    example: NEW CORP
+                  paye_reference:
+                    type: string
+                    example: 120/NC15208
+                  status:
+                    type: string
+                    example: active
+                  start_date:
+                    type: string
+                    example: "2024-06-10T00:00Z"
+                  leave_date:
+                    type: string
+                    nullable: true
+                  tax_code:
+                    type: string
+                    nullable: true
+              income:
+                type: object
+                properties:
+                  tax_year:
+                    type: string
+                    example: "2024-25"
+                  taxable_income:
+                    type: string
+                    example: "28100.91"
+                  tax_paid:
+                    type: string
+                    example: "3611.40"
+              updated_at:
+                type: string
+                example: "2026-06-05 13:03:39"
+        self_employments:
+          type: array
+          items:
+            type: object
+            properties:
+              business:
+                type: object
+                properties:
+                  business_id:
+                    type: string
+                    example: XBIS1
+              income:
+                type: object
+                properties:
+                  tax_year:
+                    type: string
+                    example: "2024-25"
+                  turnover:
+                    type: string
+                    example: "92500.00"
+                  other_income:
+                    type: string
+                    example: "1200.00"
+                  tax_deducted_at_source:
+                    type: string
+                    example: "0.00"
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              property_id:
+                type: string
+                example: XPIS1
+              tax_year:
+                type: string
+                example: "2024-25"
+              rent_received:
+                type: string
+                example: "747.45"
 
   securitySchemes:
     ApiKeyAuth:

--- a/docs.json
+++ b/docs.json
@@ -76,6 +76,13 @@
             ]
           },
           {
+            "group": "Gov Connect",
+            "pages": [
+              "api-reference/gov-connect/connections-create",
+              "api-reference/gov-connect/get"
+            ]
+          },
+          {
             "group": "Documents",
             "pages": [
               "api-reference/documents/list",

--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -623,6 +623,182 @@ curl --location --request POST 'https://api.sandbox.goteal.co/payroll/entries/pa
 }
 ```
 
+### HMRC (Gov Connect) Connection
+
+This journey connects a user to HMRC via Gov Connect using the `hmrc_untied` provider.
+Instead of returning payroll data immediately, connecting returns an `authorization_url`
+(an untied invite link) that the user follows to authorise HMRC data sharing. Once
+authorised, income data is fetched and can be retrieved with
+`GET /gov-connect/{user_id}`. You can subscribe to the `user-gov-connect-data-submitted`
+webhook event to be notified when new HMRC income data is available.
+
+**Prerequisites:** Complete User Setup above. HMRC must be enabled for the client/user
+(`hmrc_enabled: true`) and the user must have an active authorisation.
+
+#### Connect an HMRC Account `/accounts`
+
+Create an `hmrc_untied` account, selecting the flow via `extra_login_params.flow`. The
+flow must be either `non_mtd` or `mtd`.
+
+```bash
+curl --request POST \
+  --url https://api.sandbox.goteal.co/accounts \
+  --header 'Content-Type: application/json' \
+  --header 'X-API-KEY: <api-key>' \
+  --data '{
+  "user_id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
+  "payroll_provider": "hmrc_untied",
+  "extra_login_params": {
+    "flow": "mtd"
+  }
+}'
+```
+
+<Note>
+  `ni_number` may optionally be supplied in `extra_login_params`. If the user's NINO is
+  already saved against the user record it is not needed here.
+</Note>
+
+**Response Example:**
+
+```json
+{
+  "account_id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
+  "payroll_provider": "hmrc_untied",
+  "created_at": "2019-05-17T00:00:00.000Z",
+  "status": "Pending",
+  "authorization_url": "https://star-client.untied.io/invite/abc123"
+}
+```
+
+Direct the user to the `authorization_url` to complete HMRC authorisation.
+
+**Self Employed**
+
+For the self-employed flow (`"flow": "mtd"`), the user is redirected to HMRC to authorise
+Making Tax Digital access and then returned to Teal's callback. This requires an HMRC
+sandbox test user.
+
+<Note>
+  Contact Teal to be provisioned an HMRC sandbox test user. You will log in on the HMRC
+  authorisation screen using the supplied test details.
+</Note>
+
+```json
+{
+  "flow": "mtd"
+}
+```
+
+**Employed**
+
+For the employed flow (`"flow": "non_mtd"`), authorisation is verified against HMRC
+using the user's NINO and date of birth, and completion is signalled to Teal via webhook.
+The NINO and DOB must correspond to a valid HMRC test taxpayer.
+
+<Note>
+  Contact Teal to be provisioned a test user. In sandbox, the
+  `authorization_url` shows only a dummy page rather than the full HMRC authorisation flow
+  used in the self-employed journey.
+</Note>
+
+```json
+{
+  "flow": "non_mtd"
+}
+```
+
+#### Retrieve HMRC Income `/gov-connect/{user_id}`
+
+Once the account is authorised, income data is fetched automatically. Retrieve the stored
+Gov Connect income submissions for a user (MTD shape).
+
+```bash
+curl --request GET \
+  --url https://api.sandbox.goteal.co/gov-connect/{user_id} \
+  --header 'X-API-KEY: <api-key>'
+```
+
+**Response Example:**
+
+```json
+{
+  "pagination": {
+    "limit": 100,
+    "offset": 0,
+    "count": 1,
+    "total_count": 1
+  },
+  "gov_connect_submissions": [
+    {
+      "id": "3f1c0b9a-1e2d-4a5b-9c8d-0e1f2a3b4c5d",
+      "account_id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
+      "entry_id": "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+      "authorisation_id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210",
+      "identity": {
+        "name": "Sarah Chen",
+        "date_of_birth": "1990-04-22",
+        "ni_number": "AB654321C"
+      },
+      "employments": [
+        {
+          "employment": {
+            "employer_name": "Acme Corp",
+            "paye_reference": "120/NC15208",
+            "status": "active",
+            "start_date": "2018-06-01T00:00Z"
+          },
+          "income": {
+            "tax_year": "2024-25",
+            "taxable_income": "28100.91",
+            "tax_paid": "3611.40"
+          },
+          "updated_at": "2026-06-05 13:03:39"
+        }
+      ],
+      "self_employments": [
+        {
+          "business": { "business_id": "XBIS1" },
+          "income": {
+            "tax_year": "2024-25",
+            "turnover": "92500.00",
+            "other_income": "1200.00",
+            "tax_deducted_at_source": "0.00"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "property_id": "XPIS1",
+          "tax_year": "2024-25",
+          "rent_received": "747.45"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Fetch HMRC Income `/gov-connect/entries/connections`
+
+Income is fetched automatically when the account is authorised, so this step is only
+needed for subsequent retrievals — to pull fresh income data for an already-connected
+account. Any new data is persisted and can then be read via `GET /gov-connect/{user_id}`.
+This endpoint uses the user's bearer token.
+
+```bash
+curl --request POST \
+  --url https://api.sandbox.goteal.co/gov-connect/entries/connections \
+  --header 'Authorization: Bearer <bearer-token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "account_id": "95a0e70b-fe02-4f47-aef9-2efff279df71"
+}'
+```
+
+Returns `201 Created` with the income submissions when data is returned, or `200 OK`
+with an empty `gov_connect_submissions` array when there is no new data.
+
 ## General Data Retrieval
 
 #### Retrieve Payroll Data `/payroll`


### PR DESCRIPTION
## Summary

Adds documentation for the Gov Connect (HMRC) endpoints and the `hmrc_untied` connection flow.

- **Sandbox** (`sandbox.mdx`): new "HMRC (Gov Connect) Connection" journey covering `POST /accounts` with the `hmrc_untied` provider and `extra_login_params.flow`. Two personas — **Self Employed** (`flow: mtd`, redirected to HMRC, needs a sandbox test user) and **Employed** (`flow: non_mtd`, verified via NINO+DOB, sandbox shows a dummy auth page). Notes the optional `ni_number` and the `user-gov-connect-data-submitted` webhook event. Retrieve (`GET /gov-connect/{user_id}`) is shown before the subsequent-retrieval Fetch (`POST /gov-connect/entries/connections`), since the initial fetch happens as part of `POST /accounts`.
- **API Reference** (`openapi.yaml` + new MDX stubs): `GET /gov-connect/{user_id}` (X-API-KEY, pagination + filters, MTD-shaped example) and `POST /gov-connect/entries/connections` (JWT, `{account_id}` body, 200/201). New "Gov Connect" nav group in `docs.json`.

The `GovConnectSubmission` schema only documents the fields that `UntiedIncomeMapper` actually emits. `tax_year` examples use the short HMRC form (e.g. `2024-25`).

## Verification

- `mint openapi-check` — valid
- `mint dev` — sandbox and both new Gov Connect pages render (200)

Closes #130
