### PR TITLE
Update API reference labels (Query Gov/Payroll Connection, Doc Scan)

### DIFF
--- a/api-reference/gov-connect/connections-create.mdx
+++ b/api-reference/gov-connect/connections-create.mdx
@@ -4,3 +4,9 @@ openapi: 'POST /gov-connect/entries/connections'
 ---
 
 Retrieves the most recent income data for the account's authorisation. May return an empty result if no new income is found.
+
+<Info>
+This endpoint requires a valid authorisation for the user. If no active authorisation exists, the request will be rejected.
+You can optionally pass the `x-teal-authorisation-id` header to specify which authorisation to use; otherwise the system will resolve a valid authorisation automatically.
+See [Authorisations](/authorisations) for more details.
+</Info>

--- a/api-reference/gov-connect/connections-create.mdx
+++ b/api-reference/gov-connect/connections-create.mdx
@@ -2,3 +2,5 @@
 title: 'Query Gov Connection'
 openapi: 'POST /gov-connect/entries/connections'
 ---
+
+Retrieves the most recent income data for the account's authorisation. May return an empty result if no new income is found.

--- a/api-reference/gov-connect/connections-create.mdx
+++ b/api-reference/gov-connect/connections-create.mdx
@@ -1,4 +1,4 @@
 ---
-title: 'Fetch Gov Connect income'
+title: 'Query Gov Connection'
 openapi: 'POST /gov-connect/entries/connections'
 ---

--- a/api-reference/payroll/connections-create.mdx
+++ b/api-reference/payroll/connections-create.mdx
@@ -3,6 +3,8 @@ title: 'Query Payroll Connection'
 openapi: 'POST /payroll/entries/connections'
 ---
 
+Retrieves the most recent payroll data for the account's authorisation. May return an empty result if no new payroll is found.
+
 <Info>
 This endpoint requires a valid authorisation for the user. If no active authorisation exists, the request will be rejected.
 You can optionally pass the `x-teal-authorisation-id` header to specify which authorisation to use; otherwise the system will resolve a valid authorisation automatically.

--- a/api-reference/payroll/connections-create.mdx
+++ b/api-reference/payroll/connections-create.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Create a connection'
+title: 'Query Payroll Connection'
 openapi: 'POST /payroll/entries/connections'
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -83,7 +83,7 @@
             ]
           },
           {
-            "group": "Documents",
+            "group": "Doc Scan",
             "pages": [
               "api-reference/documents/list",
               "api-reference/documents/get",


### PR DESCRIPTION
## Summary

Label/heading-only updates to the API Reference (no behaviour or schema changes).

- **Gov Connect** — the fetch endpoint (`POST /gov-connect/entries/connections`) is renamed from **"Fetch Gov Connect income"** to **"Query Gov Connection"**. The Gov Connect nav group is unchanged.
- **Payroll** — the connection endpoint (`POST /payroll/entries/connections`) is renamed from **"Create a connection"** to **"Query Payroll Connection"**. This endpoint is a subsequent fetch against an already-existing connection (user or direct), so "Query" is more accurate than "Create"/"Update". The Payroll nav group is unchanged.
- **Documents** nav group renamed to **"Doc Scan"**.

Each title change updates both the left-nav endpoint label and the page header.
