### PR TITLE
Use generic hmrc provider id in docs; note to ask Teal for working id

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1672,7 +1672,7 @@ paths:
       endpoint fetches the latest income data from HMRC for that account and persists it
       on Teal's storage. The stored data can subsequently be retrieved using the
       `GET /gov-connect/{user_id}` endpoint. The account must have been established via a
-      Gov Connect connection (e.g. the `hmrc_untied` provider) and the user must have HMRC
+      Gov Connect connection (e.g. the `hmrc` provider) and the user must have HMRC
       enabled and a valid authorisation.
     post:
       summary: Fetch and store Gov Connect (HMRC) income data for an account

--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -625,19 +625,24 @@ curl --location --request POST 'https://api.sandbox.goteal.co/payroll/entries/pa
 
 ### HMRC (Gov Connect) Connection
 
-This journey connects a user to HMRC via Gov Connect using the `hmrc_untied` provider.
+This journey connects a user to HMRC via Gov Connect using the `hmrc` provider.
 Instead of returning payroll data immediately, connecting returns an `authorization_url`
-(an untied invite link) that the user follows to authorise HMRC data sharing. Once
+(an invite link) that the user follows to authorise HMRC data sharing. Once
 authorised, income data is fetched and can be retrieved with
 `GET /gov-connect/{user_id}`. You can subscribe to the `user-gov-connect-data-submitted`
 webhook event to be notified when new HMRC income data is available.
+
+<Note>
+  Ask your Teal connection for the working HMRC provider id to use for
+  `payroll_provider` in your environment.
+</Note>
 
 **Prerequisites:** Complete User Setup above. HMRC must be enabled for the client/user
 (`hmrc_enabled: true`) and the user must have an active authorisation.
 
 #### Connect an HMRC Account `/accounts`
 
-Create an `hmrc_untied` account, selecting the flow via `extra_login_params.flow`. The
+Create an `hmrc` account, selecting the flow via `extra_login_params.flow`. The
 flow must be either `non_mtd` or `mtd`.
 
 ```bash
@@ -647,7 +652,7 @@ curl --request POST \
   --header 'X-API-KEY: <api-key>' \
   --data '{
   "user_id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
-  "payroll_provider": "hmrc_untied",
+  "payroll_provider": "hmrc",
   "extra_login_params": {
     "flow": "mtd"
   }
@@ -664,7 +669,7 @@ curl --request POST \
 ```json
 {
   "account_id": "95a0e70b-fe02-4f47-aef9-2efff279df71",
-  "payroll_provider": "hmrc_untied",
+  "payroll_provider": "hmrc",
   "created_at": "2019-05-17T00:00:00.000Z",
   "status": "Pending",
   "authorization_url": "https://star-client.untied.io/invite/abc123"


### PR DESCRIPTION
## Summary

- Replace all references with `hmrc` across the docs (`sandbox.mdx` and `openapi.yaml`) — 5 occurrences (provider description, connect instruction, request/response examples, and the OpenAPI endpoint description).
- Add a `<Note>` in the Gov Connect sandbox section telling users to ask their Teal connection for the working HMRC provider id to use for `payroll_provider` in their environment.

Docs-only; `mint openapi-check` passes.
